### PR TITLE
[stackit] Separate launch files for when slower machines cannot handle controller managers

### DIFF
--- a/ros_seminar_manipulation/stackit_robot/dynamixel_all.launch
+++ b/ros_seminar_manipulation/stackit_robot/dynamixel_all.launch
@@ -1,14 +1,11 @@
 <launch>
   <arg name="debug" default="false" />
-  <arg unless="$(arg debug)" name="launch_prefix" value="" />
-  <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
   <arg name="use_viz" default="true" />
 
-  <include file="$(find stackit_robot)/controller_manager.launch" />
-  <!-- 12/6/2015 Disable due to the reported errors. See https://github.com/tork-a/delivery/issues/325#issuecomment-162515572 -->
-  <!-- <include file="$(find stackit_robot)/start_controllers.launch" /> -->
-  <include file="$(find stackit_robot)/temp.launch" />
-  <group if="$(arg use_viz)">
-    <node name="rviz_stackit" pkg="rviz" type="rviz" launch-prefix="$(arg launch_prefix)" />
-  </group>
+  <include file="$(find stackit_robot)/dynamixel_separate.launch">
+    <arg name="debug" value="false" />
+    <arg name="use_viz" value="true" />
+  </include>
+
+  <include file="$(find stackit_robot)/start_controllers.launch" />
 </launch>

--- a/ros_seminar_manipulation/stackit_robot/dynamixel_separate.launch
+++ b/ros_seminar_manipulation/stackit_robot/dynamixel_separate.launch
@@ -1,0 +1,15 @@
+<launch>
+  <!-- This file was created based on the discussion at https://github.com/tork-a/delivery/issues/325#issuecomment-164825118. 
+       Basically you should use dynamixel_all.launch to run all the necessary nodes. Only when something seems not properly running with dynamixel_all.launch, 
+       run this launch together with start_controllers.launch. -->
+  <arg name="debug" default="false" />
+  <arg unless="$(arg debug)" name="launch_prefix" value="" />
+  <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
+  <arg name="use_viz" default="true" />
+
+  <include file="$(find stackit_robot)/controller_manager.launch" />
+  <include file="$(find stackit_robot)/temp.launch" />
+  <group if="$(arg use_viz)">
+    <node name="rviz_stackit" pkg="rviz" type="rviz" launch-prefix="$(arg launch_prefix)" />
+  </group>
+</launch>

--- a/ros_seminar_manipulation/stackit_robot/temp.launch
+++ b/ros_seminar_manipulation/stackit_robot/temp.launch
@@ -1,6 +1,6 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro.py '$(find stackit_robot_description)/urdf/my_four_dof_arm.xacro'" />
-  <param name="use_gui" value="True"/>
+ <param name="robot_description" command="$(find xacro)/xacro.py '$(find stackit_robot_description)/urdf/my_four_dof_arm.xacro'" />
+ <param name="use_gui" value="True"/>
  <node name="stackit_robot_joint_states_publisher" pkg="stackit_robot" type="stackit_robot_joint_state_publisher.py" output="screen"></node>
   <node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher" output="screen">
     <param name="publish_frequency" type="double" value="20.0" />


### PR DESCRIPTION
This change is suggested at https://github.com/tork-a/delivery/issues/325#issuecomment-164825118
[As noted in the newly created launch file](https://github.com/tork-a/ros_seminar/compare/master...130s:fix/duplicate_rviz?expand=1#diff-b9f82341d3e46136127d118d97ee0146R2), you should run:
- dynamixel_all.launch in general.
- only when dynamixel_all.launch doesn't work, use dynamixel_separate.launch + start_controller.launch.