### PR TITLE
remove kinetic from allow_failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ env:
     - ROS_DISTRO_NAME=lunar   OS_NAME=ubuntu OS_CODE_NAME=xenial ARCH=amd64
 matrix:
   allow_failures:
-    - env: ROS_DISTRO_NAME=kinetic OS_NAME=ubuntu OS_CODE_NAME=xenial ARCH=amd64
     - env: ROS_DISTRO_NAME=lunar   OS_NAME=ubuntu OS_CODE_NAME=xenial ARCH=amd64
 install:
   # either install the latest released version of ros_buildfarm

--- a/ros_seminar_manipulation/stackit_robot_ikfast_whole_arm_plugin/CMakeLists.txt
+++ b/ros_seminar_manipulation/stackit_robot_ikfast_whole_arm_plugin/CMakeLists.txt
@@ -27,6 +27,9 @@ find_package(LAPACK REQUIRED)
 
 add_library(${IKFAST_LIBRARY_NAME} src/stackit_robot_whole_arm_ikfast_moveit_plugin.cpp)
 target_link_libraries(${IKFAST_LIBRARY_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${LAPACK_LIBRARIES})
+if ($ENV{ROS_DISTRO} STRGREATER "indigo")
+  target_compile_features(${IKFAST_LIBRARY_NAME} PRIVATE cxx_range_for)
+endif()
 
 install(TARGETS ${IKFAST_LIBRARY_NAME} LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 


### PR DESCRIPTION
```
参加者全員Kineticだったので，ros_seminar_manipulationのビルドに失敗

    CATKIN_IGNOREをros_seminar_manipulationに作る，のやり方を教えて回避

```